### PR TITLE
Correcting formatting in settings instructions

### DIFF
--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -69,7 +69,7 @@
 
     {{ forms.editableTableField({
         label: "Enable structures"|t('app'),
-        instructions: "Choose which entry sections should be listed in the sitemap, and configure the crawl settings. <b>Note: the sections should have url's to get listed here </b>"|t('app'),
+        instructions: "Choose which entry sections should be listed in the sitemap, and configure the crawl settings. **Note: the sections should have URLs to get listed here.**"|t('app'),
         id: 'sitemapSections',
         name: 'sitemapSections',
         cols: {
@@ -169,7 +169,7 @@ Please note that the priority you assign to a page is not likely to influence th
 
     {{ forms.editableTableField({
         label: "Enable categories"|t('app'),
-        instructions: "Choose which categories should be listed in the sitemap, and configure the crawl settings. <b>Note: the categories should have url's to get listed here </b>"|t('app'),
+        instructions: "Choose which categories should be listed in the sitemap, and configure the crawl settings. **Note: the categories should have URLs to get listed here.**"|t('app'),
         id: 'sitemapCategories',
         name: 'sitemapCategories',
         cols: {


### PR DESCRIPTION
In settings instructions text, Markdown formatting is parsed but HTML is not. Minor corrections to add the desired bold formatting using MD instead of HTML.

![Screen Shot 2019-09-27 at 17 41 51](https://user-images.githubusercontent.com/116970/65786564-cd535500-e14e-11e9-8bd0-035e3c6defbe.png)
